### PR TITLE
Fix for multibyte chars

### DIFF
--- a/stopwords.go
+++ b/stopwords.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"sync"
 	"unicode"
+	"unicode/utf8"
 
 	"github.com/derekparker/trie/v3"
 )
@@ -111,7 +112,7 @@ func iterWords(text string) iter.Seq[Match] {
 		end := 0
 		for i, r := range text {
 			if unicode.IsLetter(r) {
-				end = i + 1
+				end = i + utf8.RuneLen(r)
 				continue
 			}
 			if start < end {


### PR DESCRIPTION
Range text loops over runes and i is the byte offset of that rune in the string. If a multibyte char is encountered then the end should advance the full rune length. For example:

```
package main

import (
	"fmt"
	"unicode"
)

func main() {
	text := "André"
	end := 0
	for i, r := range text {
		if unicode.IsLetter(r) {
			end = i + 1
			// end = i + utf8.RuneLen(r)
			continue
		}
	}
	fmt.Println(text[0:end])
}
```

This code will give Andr� (for the line end = i + 1) and André for the line end = i + utf8.RuneLen(r).

é is composed of 2 chars: 0xC3 0xA9. Andr� only keeps 0xC3
